### PR TITLE
[CHORE] Add support for any json structure

### DIFF
--- a/src/internal/app/storeLogsJson.go
+++ b/src/internal/app/storeLogsJson.go
@@ -7,11 +7,10 @@ import (
 	"log"
 	"time"
 	"vector-mongodb-sink/adapters"
-	"vector-mongodb-sink/internal/common"
 )
 
 func StoreJson(b []byte, collection string) {
-	var data []common.LogRecord
+	var data []map[string]interface{}
 	var dataToInsert []interface{}
 	err := json.Unmarshal(b, &data)
 

--- a/src/internal/app/storeLogsPlainText.go
+++ b/src/internal/app/storeLogsPlainText.go
@@ -6,15 +6,13 @@ import (
 	"strings"
 	"time"
 	"vector-mongodb-sink/adapters"
-	"vector-mongodb-sink/internal/common"
 )
 
 func StorePlainText(b []byte, collection string) {
-	now := time.Now()
 	var dataToInsert []interface{}
 
 	for _, m := range strings.Split(string(b), "\n") {
-		dataToInsert = append(dataToInsert, common.LogRecord{Timestamp: now, Message: m})
+		dataToInsert = append(dataToInsert, map[string]interface{}{ "body": m })
 	}
 
 	coll := adapters.GetCollection(adapters.DB, collection)

--- a/src/internal/common/types.go
+++ b/src/internal/common/types.go
@@ -1,8 +1,0 @@
-package common
-
-import "time"
-
-type LogRecord struct {
-	Timestamp time.Time   `bson:"timestamp" json:"timestamp"`
-	Message   interface{} `bson:"message" json:"message"`
-}


### PR DESCRIPTION
Originally documents inserted to Mongo were meant to have a LogRecord structure; which was composed by a Timestamp and a Message
We want this sink to receive any json structure and store it in Mongo. To do that so, I'm removing the LogRecord type